### PR TITLE
fix(build): add Darwin to the mkversion uname allow-list

### DIFF
--- a/tools/MKVersionScript.cmake
+++ b/tools/MKVersionScript.cmake
@@ -30,7 +30,7 @@ set(MKVERSION_CANDIDATES_SH "${CMAKE_CURRENT_LIST_DIR}/mkversion.sh")
 # We are running on the Windows?
 set(MKVERSION_RUN_NATIVE_WINDOWS FALSE)
 execute_process(COMMAND uname OUTPUT_VARIABLE uname)
-if (uname MATCHES "^MSYS" OR uname MATCHES "^MINGW" OR uname MATCHES "^Lin")
+if (uname MATCHES "^MSYS" OR uname MATCHES "^MINGW" OR uname MATCHES "^Lin" OR uname MATCHES "^Darwin")
     message(STATUS "Not running on native Windows (uname is ${uname}).")
 else ()
     set(MKVERSION_RUN_NATIVE_WINDOWS TRUE)


### PR DESCRIPTION
`tools/MKVersionScript.cmake` picks the mkversion script by matching `uname` against an allow-list of MSYS/MINGW/Linux. macOS reports `Darwin`, which isn't on the list, so configure takes the native-Windows branch, tries `mkversion.bat` through `cmd`, and aborts:

```
CMake Error at tools/MKVersionScript.cmake:89 (message):
  MKVERSION_SCRIPT_TYPE must be 'sh' or 'bat', but got ''
```

The patch adds `^Darwin` to the list, nothing else. WSL (`Linux`), MSYS2 (`MSYS_NT`), and Git Bash (`MINGW64_NT`) already match, so their behavior is unchanged, and native Windows still falls through to the bat path.

Verified on macOS 26.5 (arm64), arm-none-eabi-gcc 13.3.Rel1, CMake 4.4.2. Each run used a fresh build directory, since `MKVERSION_AVAILABLE` is cached and short-circuits the script on re-configure.

- Without the patch, `cmake -DBUILD_FIRMWARE=ON -DPLATFORM=PM5` fails with the error above.
- With it, configure succeeds and a full `PLATFORM=PM5` build completes: fullimage 294193 B text / 8127 B bss, bootrom 13640 B text, both v7E-M / Thumb-2.

Cygwin (`CYGWIN_NT`) matches none of the three patterns either, so it takes the same branch. Whether that actually breaks depends on whether `cmd` is reachable from the Cygwin environment, which I can't test, so I left it alone.
