### PR TITLE
fix(build): archive armlib with the cross archiver

### DIFF
--- a/armlib/Makefile
+++ b/armlib/Makefile
@@ -26,7 +26,7 @@ include ../common_arm/Makefile.common
 CROSS ?= arm-none-eabi-
 CROSS_CC ?= $(CROSS)gcc
 CROSS_CFLAGS ?=
-AR ?= ar rcs
+CROSS_AR ?= $(CROSS)ar
 OBJDIR ?= obj
 
 ARMLIBSRC = \
@@ -89,7 +89,7 @@ $(OBJDIR):
 
 $(ARMLIB): $(ARMLIB_OBJ) | $(OBJDIR)
 	$(info [-] AR $@)
-	$(Q)$(AR) $@ $^
+	$(Q)$(CROSS_AR) rcs $@ $^
 
 $(call ARMLIB_REGISTER_RULES)
 -include $(ARMLIB_DEP)


### PR DESCRIPTION
`make PLATFORM=PM5` fails to link on macOS: 277 undefined references to AT32 driver symbols from both `fullimage` and `bootrom`.

`armlib/Makefile` archived the cross-compiled objects with `$(AR)`, which `Makefile.defs:106` sets to `/usr/bin/ar` under `IS_DARWIN`. Apple's `ar` cannot read ARM ELF, so it dropped all 33 objects and wrote an empty archive. Linux is unaffected because host GNU `ar` handles ARM ELF. The `AR ?= ar rcs` fallback never fired: make has a built-in default for `AR`, so `?=` is a no-op.

Using the cross archiver fixes it. `Makefile.defs` is left alone, since `$(AR)` is correct for its only other consumer, `Makefile.host:88`. The CMake path is unaffected; it takes `CMAKE_AR` from the cross-compiler.

Verified on macOS 26.5 (arm64), arm-none-eabi-gcc 13.3.Rel1: without the patch `make PLATFORM=PM5 fullimage` exits 2 with 0 archive members; with it, 33 members and both images link (fullimage 304,652 B, bootrom 33,580 B, `Tag_CPU_arch: v7E-M`).

Independent of #9 — that one fixes the CMake path's `uname` allow-list. Neither depends on the other.
